### PR TITLE
Refatora o tamanho da string aceitável

### DIFF
--- a/src/main/groovy/icaruswings/utils/validator/StringUtils.groovy
+++ b/src/main/groovy/icaruswings/utils/validator/StringUtils.groovy
@@ -18,7 +18,7 @@ public class StringUtils {
     }
 
     private static Boolean isValidStringLength(String str) {
-        if(str.length() < 3 || str.length() > 255) return false
+        if(str.length() < 2 || str.length() > 255) return false
 
         return true
     }


### PR DESCRIPTION
### Impaco

Com essa alteração podemos utilizar o via cep para estados que são preenchidos apenas com 2 letras(Ex.: PB, MS)

### PR Predecessora

### Prints do desenvolvimento

### Link da tarefa