### PR TITLE
Adiciona a formatação de tag libs para usar no front

### DIFF
--- a/grails-app/taglib/icaruswings/FormatTagLib.groovy
+++ b/grails-app/taglib/icaruswings/FormatTagLib.groovy
@@ -1,0 +1,13 @@
+package icaruswings
+
+class FormatTagLib {
+    static namespace = "formatTagLib"
+
+    def formatedDateCreated = { attrs, body ->
+        Date dateCreated = attrs.date
+
+        if (dateCreated) {
+            out << g.formatDate(format: "dd/MM/yyyy", date: dateCreated)
+        }
+    }
+}

--- a/grails-app/taglib/icaruswings/FormatTagLib.groovy
+++ b/grails-app/taglib/icaruswings/FormatTagLib.groovy
@@ -3,11 +3,11 @@ package icaruswings
 class FormatTagLib {
     static namespace = "formatTagLib"
 
-    def formatedDateCreated = { attrs, body ->
-        Date dateCreated = attrs.date
+    def formatedDate = { attrs, body ->
+        Date date = attrs.date
 
-        if (dateCreated) {
-            out << g.formatDate(format: "dd/MM/yyyy", date: dateCreated)
+        if (date) {
+            out << g.formatDate(format: "dd/MM/yyyy", date: date)
         }
     }
 }


### PR DESCRIPTION
### Impacto

Agora podemos utilizar taglibs para formatar datas no front

### PR Predecessora

### Prints do desenvolvimento

### Link da tarefa