### PR TITLE
refatora o metodo parse do BigDecimalUtils

### DIFF
--- a/src/main/groovy/icaruswings/utils/bigDecimal/BigDecimalUtis.groovy
+++ b/src/main/groovy/icaruswings/utils/bigDecimal/BigDecimalUtis.groovy
@@ -3,8 +3,9 @@ package icaruswings.utils.bigDecimal
 class BigDecimalUtis {
 
     public static BigDecimal parse(String stringValue) {
-        String valueWithDote = stringValue.replaceAll( "," , "." )
-        BigDecimal value = new BigDecimal(valueWithDote)
+        String valueWithoutDots = stringValue.replace( "." , "" )
+        String formattedValue = valueWithoutDots.replace( "," , "." )
+        BigDecimal value = new BigDecimal(formattedValue)
 
         return value
     }


### PR DESCRIPTION
### Impacto
refatora o metodo parse do BigDecimalUtils, pois a lógica antiga não funcionava quando recebíamos um valor com pontos, exemplo: 2.234,50
### PR Predecessora
main
