### PR TITLE
refatora função de delete do payer

### DIFF
--- a/grails-app/services/icaruswings/PayerService.groovy
+++ b/grails-app/services/icaruswings/PayerService.groovy
@@ -67,11 +67,12 @@ class PayerService {
 
         if (!payer) throw new RuntimeException("Esse pagador não existe")
 
+        List<PaymentStatus> paymentStatuses = [PaymentStatus.PENDING, PaymentStatus.OVERDUE]
+
         List<Payment> payments = PaymentRepository.query([
             payer:id,
-            paymentStatus: PaymentStatus.PENDING,
-            paymentStatus: PaymentStatus.OVERDUE
-        ]).list()
+             "paymentStatus[in]": paymentStatuses
+        ]).readOnly().list()
 
         if (!payments.isEmpty() && payments != null) throw new RuntimeException("Esse pagador tem cobranças pendentes")
 

--- a/src/main/groovy/icaruswings/repositories/PaymentRepository.groovy
+++ b/src/main/groovy/icaruswings/repositories/PaymentRepository.groovy
@@ -25,7 +25,7 @@ class PaymentRepository implements Repository<Payment, PaymentRepository> {
             }
 
             if (search.containsKey("paymentStatus[in]")) {
-                inList("paymentStatus", search."paymentStatus[in]")
+                inList("paymentStatus", search."paymentStatus[in]".collect { PaymentStatus.valueOf(it.toString()) })
             }
         }
     }

--- a/src/main/groovy/icaruswings/repositories/PaymentRepository.groovy
+++ b/src/main/groovy/icaruswings/repositories/PaymentRepository.groovy
@@ -23,6 +23,10 @@ class PaymentRepository implements Repository<Payment, PaymentRepository> {
             if (search.containsKey("payer")) {
                 eq("payer.id", Long.valueOf(search.payer.toString()))
             }
+
+            if (search.containsKey("paymentStatus[in]")) {
+                inList("paymentStatus", search."paymentStatus[in]")
+            }
         }
     }
 
@@ -32,7 +36,8 @@ class PaymentRepository implements Repository<Payment, PaymentRepository> {
                 "id",
                 "paymentStatus",
                 "dueDate[lt]",
-                "payer"
+                "payer",
+                "paymentStatus[in]"
         ]
     }
 


### PR DESCRIPTION
### Impacto
Antes a função de delete não verificava corretamente um Payer que tivesse cobranças pendentes, apenas se verificava se havia cobrança como Overdue
### PR Predecessora
main